### PR TITLE
加速开发调试时，二次打包速度

### DIFF
--- a/bin/tars-deploy
+++ b/bin/tars-deploy
@@ -44,6 +44,10 @@ if (process.argv.length == 2) {
 }
 
 var name = process.argv[2];
+var isClean = false;
+if (process.argv[3] === '--clean') {
+	isClean = true;
+}
 
 if (!/^[0-9a-z]+$/i.test(name)) {
 	console.error(chalk.red('name illegal, eg: TestServer'));
@@ -94,4 +98,4 @@ deploy.on('done', function(filepath) {
 	console.info('-- Built deploy package to: "' + filepath + '"');
 });
 
-deploy.make(name, process.cwd());
+deploy.make(name, process.cwd(), isClean);

--- a/bin/tars-deploy
+++ b/bin/tars-deploy
@@ -29,7 +29,8 @@ var deploy = require('../deploy');
 
 commander
 	.version(pkg.version)
-	.usage('name [options]')
+	.option('-c, --cache', 'use cache to speed up package, suggest use only on dev mode')
+	.usage('name [options] test')
 	.parse(process.argv)
 	.on('--help', function() {
 		console.log('  Examples:');
@@ -42,12 +43,8 @@ if (process.argv.length == 2) {
 	commander.outputHelp();
 	process.exit(0);
 }
-
 var name = process.argv[2];
-var isClean = false;
-if (process.argv[3] === '--clean') {
-	isClean = true;
-}
+var isCache = commander.cache;
 
 if (!/^[0-9a-z]+$/i.test(name)) {
 	console.error(chalk.red('name illegal, eg: TestServer'));
@@ -98,4 +95,4 @@ deploy.on('done', function(filepath) {
 	console.info('-- Built deploy package to: "' + filepath + '"');
 });
 
-deploy.make(name, process.cwd(), isClean);
+deploy.make(name, process.cwd(), isCache);

--- a/deploy.js
+++ b/deploy.js
@@ -30,7 +30,7 @@ var async = require('async');
 var fse = require('fs-extra');
 var fstream = require('fstream');
 var tar = require('tar');
-const md5 = require('md5');
+var md5 = require('md5');
 
 module.exports = exports = new events();
 
@@ -43,14 +43,7 @@ var config = exports.config = {
 	maxBuffer : 500 * 1024
 };
 
-var npmName = '';
-var testIfExistsNpm = spawnSync(process.platform === 'win32' ? 'npm.cmd' : 'tnpm', ['-v'],{stdio: 'inherit'});
-if (testIfExistsNpm.status !== 0) {
-	npmName = process.platform === 'win32' ? 'npm.cmd' : 'npm';
-} else {
-	npmName = process.platform === 'win32' ? 'tnpm.cmd' : 'tnpm';
-}
-console.log('run with ' + npmName);
+var npmName = process.platform === 'win32' ? 'npm.cmd' : 'npm';
 
 var isNeedToInstallNodeModules = true;
 var isNeedToInstallAgent = true;
@@ -358,7 +351,7 @@ var STEP_SERIES = [checkIsNeedToInstallAgent, checkIsNeedToInstallNodeModules, m
 
 exports.STEP_COUNT = STEP_SERIES.length;
 
-exports.make = function(name, dir, isClean) {
+exports.make = function(name, dir, isCache) {
 	tmpName = '_build'
 	var wrapper = function(fn) {
 		return function(callback) {
@@ -366,7 +359,7 @@ exports.make = function(name, dir, isClean) {
 		};
 	};
 
-	if (isClean) {
+	if (!isCache) {
 		STEP_SERIES.unshift(clean);
 		exports.STEP_COUNT = STEP_SERIES.length;
 	}

--- a/deploy.js
+++ b/deploy.js
@@ -23,23 +23,37 @@ var fs = require('fs');
 var path = require('path');
 var events = require('events');
 var spawn = require('child_process').spawn;
+var spawnSync = require('child_process').spawnSync;
 var zlib = require('zlib');
 
 var async = require('async');
 var fse = require('fs-extra');
 var fstream = require('fstream');
 var tar = require('tar');
+const md5 = require('md5');
 
 module.exports = exports = new events();
 
 var tmpName = '';
 
 var config = exports.config = {
-	exclude : ['.svn', '.git', '_svn', '_git', '.tgz', '_tmp_dir', '.idea'],
+	exclude : ['.svn', '.git', '_svn', '_git', '.tgz', '_tmp_dir', '.idea', '.DS_Store'],
 	level : 6,
 	memLevel : 6,
 	maxBuffer : 500 * 1024
 };
+
+var npmName = '';
+var testIfExistsNpm = spawnSync(process.platform === 'win32' ? 'npm.cmd' : 'tnpm', ['-v'],{stdio: 'inherit'});
+if (testIfExistsNpm.status !== 0) {
+	npmName = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+} else {
+	npmName = process.platform === 'win32' ? 'tnpm.cmd' : 'tnpm';
+}
+console.log('run with ' + npmName);
+
+var isNeedToInstallNodeModules = true;
+var isNeedToInstallAgent = true;
 
 var execNPM = function(command, cwd, options, cb) {
 	fs.exists(path.join(cwd, 'package.json'), function(exists) {
@@ -49,8 +63,7 @@ var execNPM = function(command, cwd, options, cb) {
 		if (!exists && command.length <= 1) {
 			return cb();
 		}
-
-		npm = spawn(process.platform === 'win32' ? 'npm.cmd' : 'npm', command, {cwd : cwd,  stdio: 'inherit'});
+		npm = spawn(npmName, command, {cwd : cwd,  stdio: 'inherit'});
 
 		npm.on('exit', function(code) {
 			var err;
@@ -63,6 +76,7 @@ var execNPM = function(command, cwd, options, cb) {
 				cb(err);
 			});
 		});
+		
 	});
 };
 
@@ -71,18 +85,12 @@ var mkdir = function(name, dir, cb) {
 	exports.emit('progress:start', 'Creating directory structure');
 
 	fs.stat(dir, function(err, stat) {
-		tmpName = '_' + name + '_' + Date.now();
-
 		if (err || !stat.isDirectory()) {
 			cb(new Error('Not a directory'));
 			return;
 		}
 
 		fs.mkdir(path.join(dir, tmpName), function(err) {
-			if (err) {
-				cb(err);
-				return;
-			}
 			fs.readdir(dir, function(err, files) {
 				if (err) {
 					cb(err);
@@ -97,10 +105,6 @@ var mkdir = function(name, dir, cb) {
 					path.join(dir, tmpName, name, name, 'tars_nodejs', 'node-agent'),
 					path.join(dir, tmpName, name, name, 'tars_nodejs', 'node-agent', 'node_modules')
 				], fs.mkdir.bind(fs), function(err) {
-					if (err) {
-						cb(err);
-						return;
-					}
 
 					async.map(files.filter(function(file) {
 						return file !== tmpName;
@@ -137,51 +141,106 @@ var cp = function(name, dir, cb) {
 	});
 };
 
+var installNodeAgent = function (name, dir, cb) {
+	exports.emit('progress:start', 'Installing node-agent');
+	var cwd = path.join(dir, tmpName, name, name, 'tars_nodejs', 'node-agent');
+
+	if (isNeedToInstallAgent) {
+		execNPM('install --global-style --no-save --loglevel error @tars/node-agent', cwd, null, function (err, stdin, stderr) {
+			exports.emit('progress:end', 'installNodeAgent finish');
+			cb(err, stdin, stderr)
+		});
+	} else {
+		exports.emit('progress:end', 'installNodeAgent finish, no need to install');
+		cb();
+	}
+}
+
 // 安装 node-agent
 var install = function(name, dir, cb) {
-	exports.emit('progress:start', 'Installing node-agent');
+	exports.emit('progress:start', 'Copying node-agent');
 
 	var cwd = path.join(dir, tmpName, name, name, 'tars_nodejs', 'node-agent');
 
-	execNPM('install --global-style --no-save --loglevel error @tars/node-agent', cwd, null, function(err, stdout, stderr) {
-		if (err) {
-			cb(err, stdout, stderr);
+	fs.exists(path.join(cwd, 'node_modules', '@tars', 'node-agent'), function(exists) {
+		if (!exists) {
+			exports.emit('progress:end', 'Installed node-agent');
+			cb();
 			return;
 		}
 
-		fs.exists(path.join(cwd, 'node_modules', '@tars', 'node-agent'), function(exists) {
-			if (!exists) {
-				cb(true, stdout, stderr);
+		fs.rename(path.join(cwd, 'node_modules', '@tars', 'node-agent'), cwd + '2', function(err) {
+			if (err) {
+				cb(err);
 				return;
 			}
-
-			fs.rename(path.join(cwd, 'node_modules', '@tars', 'node-agent'), cwd + '2', function(err) {
+			fse.remove(cwd, function(err) {
 				if (err) {
-					cb(true, stdout, stderr);
+					cb(err);
 					return;
 				}
-				fse.remove(cwd, function(err) {
+				fs.rename(cwd + '2', cwd, function(err) {
 					if (err) {
-						cb(true, stdout, stderr);
-						return;
+						cb(err);
+					} else {
+						exports.emit('progress:end', 'Installed node-agent');
+						cb(null);
 					}
-					fs.rename(cwd + '2', cwd, function(err) {
-						if (err) {
-							cb(true, stdout, stderr);
-						} else {
-							exports.emit('progress:end', 'Installed node-agent');
-							cb(null, stdout, stderr);
-						}
-					});
 				});
 			});
 		});
 	});
 };
 
+
+var checkIsNeedToInstallAgent = function(name, dir, cb) {
+	exports.emit('progress:start', 'checkIsNeedToInstallAgent');
+	var cwd = path.join(dir, tmpName, name, name, 'tars_nodejs', 'node-agent');
+
+	fs.exists(cwd, function (exists) {
+		isNeedToInstallAgent = !exists;
+		exports.emit('progress:end', 'isNeedToInstallAgent=' + isNeedToInstallAgent);
+		cb();
+	})
+}
+
+var checkIsNeedToInstallNodeModules = function(name, dir, cb) {
+	exports.emit('progress:start', 'checkIsNeedToInstallNodeModules');
+
+	var cwd = path.join(dir, tmpName, name, name, 'src');
+	fs.readFile(path.join(cwd, 'package.json'), function(err, buf) {
+		if (err) {
+			isNeedToInstallNodeModules = true;
+			exports.emit('progress:end', 'isNeedToInstallNodeModules=' + isNeedToInstallNodeModules);
+			cb();
+			return;
+		}
+		fs.readFile(path.join(dir, 'package.json'), function (err, buf2) {
+			if (err) {
+				isNeedToInstallNodeModules = true;
+			} else {
+				if (md5(buf) === md5(buf2)) {
+					isNeedToInstallNodeModules = false;
+				} else {
+					isNeedToInstallNodeModules = true;
+				}
+			}
+			exports.emit('progress:end', 'isNeedToInstallNodeModules=' + isNeedToInstallNodeModules);
+			cb();
+		});
+	});
+}
+
+
 // 安装 src 中的依赖项
 var init = function(name, dir, cb) {
 	exports.emit('progress:start', 'Installing dependency');
+
+	if (!isNeedToInstallNodeModules) {
+		exports.emit('progress:end', 'Installed dependency no need');
+		cb();
+		return;
+	}
 
 	var cwd = path.join(dir, tmpName, name, name, 'src');
 	
@@ -204,6 +263,12 @@ var init = function(name, dir, cb) {
 // 重新编译
 var rebuild = function(name, dir, cb) {
 	exports.emit('progress:start', 'Building C/C++ modules');
+
+	if (!isNeedToInstallNodeModules) {
+		exports.emit('progress:end', 'No Need to build C/C++ modules');
+		cb();
+		return;
+	}
 
 	var cwd = path.join(dir, tmpName, name, name, 'src');
 	execNPM('rebuild', cwd, null, function(err, stdout, stderr) {
@@ -249,47 +314,30 @@ var rebuild = function(name, dir, cb) {
 var pack = function(name, dir, cb) {
 	exports.emit('progress:start', 'Making deploy package');
 
-	var dirDest = fs.createWriteStream(path.join(dir, name + '.tgz')),
-		packer = tar.Pack({
-			noProprietary: true
-		}),
-		gzip = zlib.createGzip({
+	tar.c({
+		gzip: {
 			level: config.level,
 			memLevel: config.memLevel
-		}),
-		reader = fstream.Reader({
-			path: path.join(dir, tmpName, name),
-			type: "Directory",
-			filter : function(entry) {
-				if (entry.props.Directory || path.extname(entry.props.basename) === '') {
-					entry.props.mode = 493; // 0755
+		},
+		filter: function (_path, stat) {
+			return !config.exclude.some(name => {
+				if (_path.indexOf(name) !== -1) {
+					return true;
 				}
+				return false;
+			});
+		},
+		cwd: path.join(dir, tmpName)
+	}, [
+		'./'
+	]).pipe(
+		fs.createWriteStream(path.join(dir, name + '.tgz'))
+	).on('close', function () {
+		exports.emit('progress:end', 'Made deploy package');
+		cb();
+	})
 
-				return !config.exclude.some(function(name) {
-					if (entry.props.basename.indexOf(name) !== -1) {
-						return entry.props.basename.indexOf(name) === entry.props.basename.length - name.length;
-					} else {
-						return false;
-					}
-				});
-			}
-		}),
-		complete = function(err) {
-			if (!err) {
-				exports.emit('progress:end', 'Made deploy package');
-			}
-
-			cb(err);
-		};
-
-	reader.on('error', complete);
-	packer.on('error', complete);
-	gzip.on('error', complete);
-	dirDest.on('error', complete);
-
-	dirDest.on('close', complete);
-
-	reader.pipe(packer).pipe(gzip).pipe(dirDest);
+	return;
 };
 
 // 删除临时文件
@@ -306,16 +354,22 @@ var clean = function(name, dir, cb) {
 	});
 };
 
-var STEP_SERIES = [mkdir, cp, install, init, rebuild, pack, clean];
+var STEP_SERIES = [checkIsNeedToInstallAgent, checkIsNeedToInstallNodeModules, mkdir, cp, installNodeAgent, install, init, rebuild, pack];
 
 exports.STEP_COUNT = STEP_SERIES.length;
 
-exports.make = function(name, dir) {
+exports.make = function(name, dir, isClean) {
+	tmpName = '_build'
 	var wrapper = function(fn) {
 		return function(callback) {
 			fn(name, dir, callback);
 		};
 	};
+
+	if (isClean) {
+		STEP_SERIES.unshift(clean);
+		exports.STEP_COUNT = STEP_SERIES.length;
+	}
 
 	async.series(STEP_SERIES.map(function(fn) {
 		return wrapper(fn);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,297 @@
+{
+  "name": "@tars/deploy",
+  "version": "2.0.4",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "http://r.tnpm.oa.com/ansi-regex/download/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "http://r.tnpm.oa.com/ansi-styles/download/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+    },
+    "async": {
+      "version": "2.1.5",
+      "resolved": "http://r.tnpm.oa.com/async/download/async-2.1.5.tgz",
+      "integrity": "sha1-5YfGhYCZSsZ/xW/4bTrFa9voELw=",
+      "requires": {
+        "lodash": "^4.14.0"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "http://r.tnpm.oa.com/balanced-match/download/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "http://r.tnpm.oa.com/brace-expansion/download/brace-expansion-1.1.11.tgz",
+      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "http://r.tnpm.oa.com/chalk/download/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "requires": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      }
+    },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "http://r.tnpm.oa.com/charenc/download/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
+    },
+    "chownr": {
+      "version": "1.1.1",
+      "resolved": "http://r.tnpm.oa.com/chownr/download/chownr-1.1.1.tgz",
+      "integrity": "sha1-VHJri4//TfBTxCGH6AH7RBLfFJQ="
+    },
+    "commander": {
+      "version": "2.9.0",
+      "resolved": "http://r.tnpm.oa.com/commander/download/commander-2.9.0.tgz",
+      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+      "requires": {
+        "graceful-readlink": ">= 1.0.0"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "http://r.tnpm.oa.com/concat-map/download/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "http://r.tnpm.oa.com/crypt/download/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "http://r.tnpm.oa.com/escape-string-regexp/download/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "fs-extra": {
+      "version": "2.0.0",
+      "resolved": "http://r.tnpm.oa.com/fs-extra/download/fs-extra-2.0.0.tgz",
+      "integrity": "sha1-M3NSve1KC3FPPrhN6M6nZenTdgA=",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^2.1.0"
+      }
+    },
+    "fs-minipass": {
+      "version": "1.2.6",
+      "resolved": "http://r.tnpm.oa.com/fs-minipass/download/fs-minipass-1.2.6.tgz",
+      "integrity": "sha1-LFzDDe2BKCv+ig18fBhT3esQLAc=",
+      "requires": {
+        "minipass": "^2.2.1"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "http://r.tnpm.oa.com/fs.realpath/download/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "fstream": {
+      "version": "1.0.12",
+      "resolved": "http://r.tnpm.oa.com/fstream/download/fstream-1.0.12.tgz",
+      "integrity": "sha1-Touo7i1Ivk99DeUFRVVI6uWTIEU=",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
+      }
+    },
+    "glob": {
+      "version": "7.1.4",
+      "resolved": "http://r.tnpm.oa.com/glob/download/glob-7.1.4.tgz",
+      "integrity": "sha1-qmCKL2xXetNX4a5aXCbZqNGWklU=",
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.15",
+      "resolved": "http://r.tnpm.oa.com/graceful-fs/download/graceful-fs-4.1.15.tgz",
+      "integrity": "sha1-/7cD4QZuig7qpMi4C6klPu77+wA="
+    },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "http://r.tnpm.oa.com/graceful-readlink/download/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "http://r.tnpm.oa.com/has-ansi/download/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "http://r.tnpm.oa.com/inflight/download/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "http://r.tnpm.oa.com/inherits/download/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "http://r.tnpm.oa.com/is-buffer/download/is-buffer-1.1.6.tgz",
+      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
+    },
+    "jsonfile": {
+      "version": "2.4.0",
+      "resolved": "http://r.tnpm.oa.com/jsonfile/download/jsonfile-2.4.0.tgz",
+      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "lodash": {
+      "version": "4.17.11",
+      "resolved": "http://r.tnpm.oa.com/lodash/download/lodash-4.17.11.tgz",
+      "integrity": "sha1-s56mIp72B+zYniyN8SU2iRysm40="
+    },
+    "md5": {
+      "version": "2.2.1",
+      "resolved": "http://r.tnpm.oa.com/md5/download/md5-2.2.1.tgz",
+      "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+      "requires": {
+        "charenc": "~0.0.1",
+        "crypt": "~0.0.1",
+        "is-buffer": "~1.1.1"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "http://r.tnpm.oa.com/minimatch/download/minimatch-3.0.4.tgz",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "http://r.tnpm.oa.com/minimist/download/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+    },
+    "minipass": {
+      "version": "2.3.5",
+      "resolved": "http://r.tnpm.oa.com/minipass/download/minipass-2.3.5.tgz",
+      "integrity": "sha1-ys6+SSAiSX9law8PUeJoKp7S2Eg=",
+      "requires": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      }
+    },
+    "minizlib": {
+      "version": "1.2.1",
+      "resolved": "http://r.tnpm.oa.com/minizlib/download/minizlib-1.2.1.tgz",
+      "integrity": "sha1-3SfqYTYkPHyIBoToZyuzpF/ZthQ=",
+      "requires": {
+        "minipass": "^2.2.1"
+      }
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "http://r.tnpm.oa.com/mkdirp/download/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "http://r.tnpm.oa.com/once/download/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "pad": {
+      "version": "1.1.0",
+      "resolved": "http://r.tnpm.oa.com/pad/download/pad-1.1.0.tgz",
+      "integrity": "sha1-en0YUgDrrDL58S7nVsOh0IezGQs="
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "http://r.tnpm.oa.com/path-is-absolute/download/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "rimraf": {
+      "version": "2.6.3",
+      "resolved": "http://r.tnpm.oa.com/rimraf/download/rimraf-2.6.3.tgz",
+      "integrity": "sha1-stEE/g2Psnz54KHNqCYt04M8bKs=",
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "http://r.tnpm.oa.com/safe-buffer/download/safe-buffer-5.1.2.tgz",
+      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "http://r.tnpm.oa.com/strip-ansi/download/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "http://r.tnpm.oa.com/supports-color/download/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+    },
+    "tar": {
+      "version": "4.4.10",
+      "resolved": "http://r.tnpm.oa.com/tar/download/tar-4.4.10.tgz",
+      "integrity": "sha1-lGsoELml4LJhQM94vqawsNaJ66E=",
+      "requires": {
+        "chownr": "^1.1.1",
+        "fs-minipass": "^1.2.5",
+        "minipass": "^2.3.5",
+        "minizlib": "^1.2.1",
+        "mkdirp": "^0.5.0",
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.3"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "http://r.tnpm.oa.com/wrappy/download/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "yallist": {
+      "version": "3.0.3",
+      "resolved": "http://r.tnpm.oa.com/yallist/download/yallist-3.0.3.tgz",
+      "integrity": "sha1-tLBJ4xS+VF486AIjbWzSLNkcPek="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -20,13 +20,14 @@
     "tars"
   ],
   "dependencies": {
-    "commander": "2.9.0",
-    "chalk": "1.1.3",
     "async": "2.1.5",
+    "chalk": "1.1.3",
+    "commander": "2.9.0",
     "fs-extra": "2.0.0",
-    "fstream": "1.0.11",
-    "tar": "2.2.1",
-    "pad": "1.1.0"
+    "fstream": "^1.0.12",
+    "md5": "^2.2.1",
+    "pad": "1.1.0",
+    "tar": "^4.4.10"
   },
   "bin": {
     "tars-deploy": "./bin/tars-deploy"


### PR DESCRIPTION
构建缓存目录修改为_build
默认不会清理缓存目录，package.json如果没有更新，打包时不会重新下载依赖
构建时添加--clean可先清理缓存目录再打包，如tars-deploy TestService --clean